### PR TITLE
Update reference to Working Group data

### DIFF
--- a/pages/working-groups.md
+++ b/pages/working-groups.md
@@ -19,7 +19,7 @@ to report on progress, for individuals to ask for help, and for interested exper
 to give feedback on training initiatives.
 * Each working group should post a general description of the group's purpose in their Slack channel description and set one or more initial goals. Goals can be added or updated at any time and removed when done or it's decided that they're no longer goals.
 
-Memorialize the following information in the [working groups folder](https://github.com/18F/data-private/tree/master/working_groups):  
+Memorialize the following information in the [working groups folder](https://github.com/18F/team-api.18f.gov/tree/master/_data/working-groups):  
 * Leads  
 * Mission  
 * Quantitative or qualitative measurements and key results   


### PR DESCRIPTION
This changeset updates the Working Group data link from the `data-private` repo to the `team-api.18f.gov` repo.  This is in reference to this issue: https://github.com/18F/team-api.18f.gov/issues/169

/cc @mtorres253 @andrewmaier @mbland 
